### PR TITLE
Fix build errors and warnings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "165fc6d22394c1168ff76ab5d951245971ef07e5",
-        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-06-05-a"
+        "revision" : "2e3c42cf38defd998c87ecfe8df138f925d22736",
+        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-15-a"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-syntax.git",
-            from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-04-25-b"),
+            exact: "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-15-a"
+        ),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
         .package(url: "https://github.com/SwiftPackageIndex/SPIManifest.git", from: "0.12.0"),
     ],

--- a/Sources/MacroToolkit/Attribute.swift
+++ b/Sources/MacroToolkit/Attribute.swift
@@ -13,7 +13,7 @@ public struct Attribute {
     /// Creates a new attribute with the given name.
     public init(named name: String) {
         _syntax = AttributeSyntax(
-            attributeName: SimpleTypeIdentifierSyntax(
+            attributeName: IdentifierTypeSyntax(
                 name: .identifier("DictionaryStorage")
             )
         )

--- a/Sources/MacroToolkit/AttributeListElement.swift
+++ b/Sources/MacroToolkit/AttributeListElement.swift
@@ -42,7 +42,7 @@ extension Sequence where Element == AttributeListElement {
                     element = .ifConfigDecl(
                         conditionalCompilationBlock._syntax.with(\.trailingTrivia, [.spaces(1)]))
             }
-            list = list.appending(element)
+            list += [element]
         }
         return list
     }

--- a/Sources/MacroToolkit/BooleanLiteral.swift
+++ b/Sources/MacroToolkit/BooleanLiteral.swift
@@ -10,6 +10,6 @@ public struct BooleanLiteral: LiteralProtocol {
     }
 
     public var value: Bool {
-        _syntax.booleanLiteral.tokenKind == .keyword(.true)
+        _syntax.literal.tokenKind == .keyword(.true)
     }
 }

--- a/Sources/MacroToolkit/ConstrainedSugarType.swift
+++ b/Sources/MacroToolkit/ConstrainedSugarType.swift
@@ -2,11 +2,11 @@ import SwiftSyntax
 
 /// Wraps a constrained sugar type (i.e. `any Protocol` or `some Protocol`).
 public struct ConstrainedSugarType: TypeProtocol {
-    public var _baseSyntax: ConstrainedSugarTypeSyntax
+    public var _baseSyntax: SomeOrAnyTypeSyntax
     public var _attributedSyntax: AttributedTypeSyntax?
 
     public init(
-        _ syntax: ConstrainedSugarTypeSyntax,
+        _ syntax: SomeOrAnyTypeSyntax,
         attributedSyntax: AttributedTypeSyntax? = nil
     ) {
         _baseSyntax = syntax

--- a/Sources/MacroToolkit/Enum.swift
+++ b/Sources/MacroToolkit/Enum.swift
@@ -16,7 +16,7 @@ public struct Enum {
     }
 
     public var identifier: String {
-        _syntax.identifier.withoutTrivia().text
+        _syntax.name.withoutTrivia().text
     }
 
     public var cases: [EnumCase] {

--- a/Sources/MacroToolkit/EnumCase.swift
+++ b/Sources/MacroToolkit/EnumCase.swift
@@ -10,15 +10,15 @@ public struct EnumCase {
 
     /// The case's name
     public var identifier: String {
-        _syntax.identifier.withoutTrivia().description
+        _syntax.name.withoutTrivia().description
     }
 
     /// The value associated with the enum case (either associated or raw).
     public var value: EnumCaseValue? {
         if let rawValue = _syntax.rawValue {
             return .rawValue(rawValue)
-        } else if let associatedValue = _syntax.associatedValue {
-            let parameters = Array(associatedValue.parameterList)
+        } else if let associatedValue = _syntax.parameterClause {
+            let parameters = Array(associatedValue.parameters)
                 .map(EnumCaseAssociatedValueParameter.init)
             return .associatedValue(parameters)
         } else {
@@ -27,6 +27,6 @@ public struct EnumCase {
     }
 
     public func withoutValue() -> Self {
-        EnumCase(_syntax.with(\.rawValue, nil).with(\.associatedValue, nil))
+        EnumCase(_syntax.with(\.rawValue, nil).with(\.parameterClause, nil))
     }
 }

--- a/Sources/MacroToolkit/FloatLiteral.swift
+++ b/Sources/MacroToolkit/FloatLiteral.swift
@@ -17,8 +17,8 @@ public struct FloatLiteral: LiteralProtocol {
     public init?(_ syntax: any ExprSyntaxProtocol) {
         guard
             let operatorSyntax = syntax.as(PrefixOperatorExprSyntax.self),
-            operatorSyntax.operatorToken?.tokenKind == .prefixOperator("-"),
-            let literalSyntax = operatorSyntax.postfixExpression.as(FloatLiteralExprSyntax.self)
+            operatorSyntax.operator.tokenKind == .prefixOperator("-"),
+            let literalSyntax = operatorSyntax.expression.as(FloatLiteralExprSyntax.self)
         else {
             // Just treat it as a regular integer literal
             guard let literal = syntax.as(FloatLiteralExprSyntax.self).map(Self.init) else {
@@ -32,7 +32,7 @@ public struct FloatLiteral: LiteralProtocol {
     }
 
     public var value: Double {
-        let string = _syntax.floatingDigits.text
+        let string = _syntax.literal.text
 
         let isHexadecimal: Bool
         let stringWithoutPrefix: String

--- a/Sources/MacroToolkit/Function.swift
+++ b/Sources/MacroToolkit/Function.swift
@@ -16,11 +16,11 @@ public struct Function {
     }
 
     public var identifier: String {
-        _syntax.identifier.text
+        _syntax.name.text
     }
 
     public var returnType: Type? {
-        (_syntax.signature.output?.returnType).map(Type.init)
+        (_syntax.signature.returnClause?.type).map(Type.init)
     }
 
     public var returnsVoid: Bool {
@@ -36,17 +36,17 @@ public struct Function {
     }
 
     public var parameters: [FunctionParameter] {
-        Array(_syntax.signature.input.parameterList).map(FunctionParameter.init)
+        Array(_syntax.signature.parameterClause.parameters).map(FunctionParameter.init)
     }
 
     public var attributes: [AttributeListElement] {
-        _syntax.attributes.map(Array.init)?.map { attribute in
+        _syntax.attributes.map { attribute in
             switch attribute {
                 case .attribute(let attributeSyntax):
                     return .attribute(Attribute(attributeSyntax))
                 case .ifConfigDecl(let ifConfigDeclSyntax):
                     return .conditionalCompilationBlock(ConditionalCompilationBlock(ifConfigDeclSyntax))
             }
-        } ?? []
+        }
     }
 }

--- a/Sources/MacroToolkit/FunctionParameter.swift
+++ b/Sources/MacroToolkit/FunctionParameter.swift
@@ -61,7 +61,7 @@ extension Sequence where Element == FunctionParameter {
         for (index, parameter) in parameters.enumerated() {
             let isLast = index == parameters.count - 1
             let syntax = parameter._syntax.with(\.trailingComma, isLast ? nil : TokenSyntax.commaToken())
-            list = list.appending(syntax)
+            list += [syntax]
         }
         return list
     }

--- a/Sources/MacroToolkit/FunctionType.swift
+++ b/Sources/MacroToolkit/FunctionType.swift
@@ -15,11 +15,11 @@ public struct FunctionType: TypeProtocol {
 
     /// The return type that the function type describes.
     public var returnType: Type {
-        Type(_baseSyntax.output.returnType)
+        Type(_baseSyntax.returnClause.type)
     }
 
     /// The types of the parameters the function type describes.
     public var parameters: [Type] {
-        _baseSyntax.arguments.map(\.type).map(Type.init)
+        _baseSyntax.parameters.map(\.type).map(Type.init)
     }
 }

--- a/Sources/MacroToolkit/IntegerLiteral.swift
+++ b/Sources/MacroToolkit/IntegerLiteral.swift
@@ -18,8 +18,8 @@ public struct IntegerLiteral: LiteralProtocol {
         //       Floating point literals are an even better example, (`-0xFp-2` anyone?)
         guard
             let operatorSyntax = syntax.as(PrefixOperatorExprSyntax.self),
-            operatorSyntax.operatorToken?.tokenKind == .prefixOperator("-"),
-            let literalSyntax = operatorSyntax.postfixExpression.as(IntegerLiteralExprSyntax.self)
+            operatorSyntax.operator.tokenKind == .prefixOperator("-"),
+            let literalSyntax = operatorSyntax.expression.as(IntegerLiteralExprSyntax.self)
         else {
             // Just treat it as a regular integer literal
             guard let literal = syntax.as(IntegerLiteralExprSyntax.self).map(Self.init) else {
@@ -33,7 +33,7 @@ public struct IntegerLiteral: LiteralProtocol {
     }
 
     public var value: Int {
-        let string = _syntax.digits.text
+        let string = _syntax.literal.text
 
         var prefixCount = 2
         let radix: Int

--- a/Sources/MacroToolkit/MacroAttribute.swift
+++ b/Sources/MacroToolkit/MacroAttribute.swift
@@ -7,8 +7,8 @@ public struct MacroAttribute {
     public var _syntax: AttributeSyntax
 
     /// The syntax node representing the attribute's arguments (if any).
-    public var _argumentListSyntax: TupleExprElementListSyntax? {
-        if case let .argumentList(arguments) = _syntax.argument {
+    public var _argumentListSyntax: LabeledExprListSyntax? {
+        if case let .argumentList(arguments) = _syntax.arguments {
             return arguments
         } else {
             return nil

--- a/Sources/MacroToolkit/MemberType.swift
+++ b/Sources/MacroToolkit/MemberType.swift
@@ -2,11 +2,11 @@ import SwiftSyntax
 
 /// Wraps a member type (e.g. `Array<Int>.Element`).
 public struct MemberType: TypeProtocol {
-    public var _baseSyntax: MemberTypeIdentifierSyntax
+    public var _baseSyntax: MemberTypeSyntax
     public var _attributedSyntax: AttributedTypeSyntax?
 
     public init(
-        _ syntax: MemberTypeIdentifierSyntax,
+        _ syntax: MemberTypeSyntax,
         attributedSyntax: AttributedTypeSyntax? = nil
     ) {
         _baseSyntax = syntax

--- a/Sources/MacroToolkit/PackReferenceType.swift
+++ b/Sources/MacroToolkit/PackReferenceType.swift
@@ -2,10 +2,10 @@ import SwiftSyntax
 
 /// Wraps an implicitly unwrapped optional type (e.g. `each V`).
 public struct PackReferenceType: TypeProtocol {
-    public var _baseSyntax: PackReferenceTypeSyntax
+    public var _baseSyntax: PackElementTypeSyntax
     public var _attributedSyntax: AttributedTypeSyntax?
 
-    public init(_ syntax: PackReferenceTypeSyntax, attributedSyntax: AttributedTypeSyntax? = nil) {
+    public init(_ syntax: PackElementTypeSyntax, attributedSyntax: AttributedTypeSyntax? = nil) {
         _baseSyntax = syntax
         _attributedSyntax = attributedSyntax
     }

--- a/Sources/MacroToolkit/RegexLiteral.swift
+++ b/Sources/MacroToolkit/RegexLiteral.swift
@@ -11,12 +11,12 @@ public struct RegexLiteral: LiteralProtocol {
 
     /// On macOS 13.0 and up you can use ``RegexLiteral/regexValue()`` to get the parsed regex value.
     public var value: String {
-        _syntax.regexPattern.text
+        _syntax.regex.text
     }
 
     /// Rethrows parsing errors thrown by the `Regex` initializer.
     @available(macOS 13.0, *)
     public func regexValue() throws -> Regex<AnyRegexOutput> {
-        return try Regex(_syntax.regexPattern.text)
+        return try Regex(_syntax.regex.text)
     }
 }

--- a/Sources/MacroToolkit/SimpleType.swift
+++ b/Sources/MacroToolkit/SimpleType.swift
@@ -2,11 +2,11 @@ import SwiftSyntax
 
 /// Wraps a simple type (e.g. `Result<Success, Failure>`).
 public struct SimpleType: TypeProtocol {
-    public var _baseSyntax: SimpleTypeIdentifierSyntax
+    public var _baseSyntax: IdentifierTypeSyntax
     public var _attributedSyntax: AttributedTypeSyntax?
 
     public init(
-        _ syntax: SimpleTypeIdentifierSyntax,
+        _ syntax: IdentifierTypeSyntax,
         attributedSyntax: AttributedTypeSyntax? = nil
     ) {
         _baseSyntax = syntax
@@ -22,7 +22,7 @@ public struct SimpleType: TypeProtocol {
     /// `Dictionary<Int, String>` it would be `["Int", "String"]`).
     public var genericArguments: [Type]? {
         _baseSyntax.genericArgumentClause.map { clause in
-            clause.arguments.map(\.argumentType).map(Type.init)
+            clause.arguments.map(\.argument).map(Type.init)
         }
     }
 }

--- a/Sources/MacroToolkit/StringLiteral.swift
+++ b/Sources/MacroToolkit/StringLiteral.swift
@@ -33,7 +33,7 @@ public struct StringLiteral: LiteralProtocol {
 
         // TODO: Modularise this code a bit to clean it up
         // The length of the `\###...` sequence that starts an escape sequence (zero hashes if not a raw string)
-        let escapeSequenceDelimiterLength = (_syntax.openDelimiter?.text.count ?? 0) + 1
+        let escapeSequenceDelimiterLength = (_syntax.openingPounds?.text.count ?? 0) + 1
         // Evaluate backslash escape sequences within each segment before joining them together
         let transformedSegments = segments.map { segment in
             var characters: [Character] = []

--- a/Sources/MacroToolkit/Struct.swift
+++ b/Sources/MacroToolkit/Struct.swift
@@ -26,7 +26,7 @@ public struct Struct {
 
     /// Types that the struct conforms to.
     public var inheritedTypes: [Type] {
-        _syntax.inheritanceClause?.inheritedTypeCollection.map(\.typeName).map(Type.init) ?? []
+        _syntax.inheritanceClause?.inheritedTypes.map(\.type).map(Type.init) ?? []
     }
 
     /// Whether the `struct` was declared with the `public` access level modifier.

--- a/Sources/MacroToolkit/SwiftSyntax+Extensions.swift
+++ b/Sources/MacroToolkit/SwiftSyntax+Extensions.swift
@@ -105,8 +105,8 @@ extension FunctionDeclSyntax {
             \.signature,
             signature
                 .with(
-                    \.input,
-                    ParameterClauseSyntax(parameterList: parameters.asParameterList)
+                    \.parameterClause,
+                    FunctionParameterClauseSyntax(parameters: parameters.asParameterList)
                 )
         )
     }
@@ -118,15 +118,15 @@ extension FunctionDeclSyntax {
                 \.signature,
                 signature
                     .with(
-                        \.output,
+                        \.returnClause,
                         ReturnClauseSyntax(
                             leadingTrivia: " ",
-                            returnType: type._syntax
+                            type: type._syntax
                         )
                     )
             )
         } else {
-            return with(\.signature, signature.with(\.output, nil))
+            return with(\.signature, signature.with(\.returnClause, nil))
         }
     }
 
@@ -181,6 +181,6 @@ extension CodeBlockSyntax {
 extension DeclGroupSyntax {
     /// Gets whether a declaration group has the `public` access level modifier.
     public var isPublic: Bool {
-        modifiers?.contains { $0.name.tokenKind == .keyword(.public) } == true
+        modifiers.contains { $0.name.tokenKind == .keyword(.public) } == true
     }
 }

--- a/Sources/MacroToolkit/Variable.swift
+++ b/Sources/MacroToolkit/Variable.swift
@@ -32,7 +32,7 @@ public struct Variable {
 
     /// The attributes attached to the variable declaration.
     public var attributes: [AttributeListElement] {
-        _syntax.attributes.map(Array.init)?.map { attribute in
+        _syntax.attributes.map { attribute in
             switch attribute {
                 case .attribute(let attributeSyntax):
                     return .attribute(Attribute(attributeSyntax))
@@ -41,7 +41,7 @@ public struct Variable {
                         ConditionalCompilationBlock(ifConfigDeclSyntax)
                     )
             }
-        } ?? []
+        }
     }
 
     /// Determines whether the variable has the syntax of a stored property.
@@ -54,7 +54,7 @@ public struct Variable {
         }
 
         for accessor in binding.accessors {
-            switch accessor.accessorKind.tokenKind {
+            switch accessor.accessorSpecifier.tokenKind {
                 case .keyword(.willSet), .keyword(.didSet):
                     break
                 default:

--- a/Sources/MacroToolkit/VariableBinding.swift
+++ b/Sources/MacroToolkit/VariableBinding.swift
@@ -21,12 +21,12 @@ public struct VariableBinding {
     /// }
     /// ```
     public var accessors: [AccessorDeclSyntax] {
-        switch _syntax.accessor {
+        switch _syntax.accessorBlock?.accessors {
             case .accessors(let block):
-                return Array(block.accessors)
+                return Array(block)
             case .getter(let getter):
                 // TODO: Avoid synthesising syntax here (wouldn't work with diagnostics)
-                return [AccessorDeclSyntax(accessorKind: .keyword(.get), body: getter)]
+                return [AccessorDeclSyntax(accessorSpecifier: .keyword(.get)) { getter }]
             case .none:
                 return []
         }

--- a/Sources/MacroToolkitExample/MacroToolkitExample.swift
+++ b/Sources/MacroToolkitExample/MacroToolkitExample.swift
@@ -15,7 +15,7 @@ public macro addBlocker<T>(_ value: T) -> T =
     #externalMacro(module: "MacroToolkitExamplePlugin", type: "AddBlockerMacro")
 
 @attached(member, names: arbitrary)
-@attached(conformance)
+@attached(extension)
 public macro MyOptionSet<RawType>() =
     #externalMacro(module: "MacroToolkitExamplePlugin", type: "OptionSetMacro")
 

--- a/Sources/MacroToolkitExamplePlugin/AddAsyncMacro.swift
+++ b/Sources/MacroToolkitExamplePlugin/AddAsyncMacro.swift
@@ -76,9 +76,13 @@ public struct AddAsyncMacro: PeerMacro {
             }
             """
 
+        let continuationExpr = isResultReturn
+        ? "try await withCheckedThrowingContinuation { continuation in"
+        : "await withCheckedContinuation { continuation in"
+
         let newBody: ExprSyntax =
             """
-            \(isResultReturn ? "try await withCheckedThrowingContinuation { continuation in" : "await withCheckedContinuation { continuation in")
+            \(raw: continuationExpr)
                 \(raw: function.identifier)(\(raw: callArguments.joined(separator: ", "))) { returnValue in
                     \(isResultReturn ? switchBody : "continuation.resume(returning: returnValue)")
                 }

--- a/Sources/MacroToolkitExamplePlugin/AddBlockerMacro.swift
+++ b/Sources/MacroToolkitExamplePlugin/AddBlockerMacro.swift
@@ -16,25 +16,25 @@ public struct AddBlockerMacro: ExpressionMacro {
         override func visit(
             _ node: BinaryOperatorExprSyntax
         ) -> ExprSyntax {
-            if node.operatorToken.text == "+" {
+            if node.operator.text == "+" {
                 let messageID = MessageID(domain: "ExampleMacros", id: "addBlocker")
                 diagnostics.append(
-                    DiagnosticBuilder(for: node.operatorToken)
+                    DiagnosticBuilder(for: node.operator)
                         .message("blocked an add; did you mean to subtract?")
                         .messageID(messageID)
                         .severity(.warning)
                         .suggestReplacement(
                             "use '-'",
-                            old: node.operatorToken,
-                            new: node.operatorToken.with(\.tokenKind, .binaryOperator("-"))
+                            old: node.operator,
+                            new: node.operator.with(\.tokenKind, .binaryOperator("-"))
                         )
                         .build()
                 )
 
                 return ExprSyntax(
                     node.with(
-                        \.operatorToken,
-                        node.operatorToken.with(\.tokenKind, .binaryOperator("-"))
+                        \.operator,
+                         node.operator.with(\.tokenKind, .binaryOperator("-"))
                     )
                 )
             }

--- a/Tests/MacroToolkitTests/MacroToolkitTests.swift
+++ b/Tests/MacroToolkitTests/MacroToolkitTests.swift
@@ -99,6 +99,7 @@ final class MacroToolkitTests: XCTestCase {
 
             enum Colours {
                 case red, gray(darkness: Int)
+
                 var isRed: Bool {
                     if case .red = self {
                         return true
@@ -106,6 +107,7 @@ final class MacroToolkitTests: XCTestCase {
 
                     return false
                 }
+
                 var isGray: Bool {
                     if case .gray = self {
                         return true
@@ -117,6 +119,7 @@ final class MacroToolkitTests: XCTestCase {
             enum Colours: Int {
                 case red = 1, green = 2
                 case blue
+
                 var isRed: Bool {
                     if case .red = self {
                         return true
@@ -124,6 +127,7 @@ final class MacroToolkitTests: XCTestCase {
 
                     return false
                 }
+
                 var isGreen: Bool {
                     if case .green = self {
                         return true
@@ -131,6 +135,7 @@ final class MacroToolkitTests: XCTestCase {
 
                     return false
                 }
+
                 var isBlue: Bool {
                     if case .blue = self {
                         return true
@@ -196,22 +201,33 @@ final class MacroToolkitTests: XCTestCase {
 
                 static let express: ShippingOptions = [.nextDay, .secondDay]
                 static let all: ShippingOptions = [.express, .priority, .standard]
+
                 typealias RawValue = UInt8
+
                 var rawValue: RawValue
+
                 init() {
                     self.rawValue = 0
                 }
+
                 init(rawValue: RawValue) {
                     self.rawValue = rawValue
                 }
+
                 static let nextDay: Self =
                     Self (rawValue: 1 << Options.nextDay.rawValue)
+
                 static let secondDay: Self =
                     Self (rawValue: 1 << Options.secondDay.rawValue)
+
                 static let priority: Self =
                     Self (rawValue: 1 << Options.priority.rawValue)
+
                 static let standard: Self =
                     Self (rawValue: 1 << Options.standard.rawValue)
+            }
+
+            extension ShippingOptions: OptionSet {
             }
             """,
             macros: testMacros
@@ -232,11 +248,12 @@ final class MacroToolkitTests: XCTestCase {
             public enum Color {
                 case red, green, blue
                 case gray(darkness: Float)
+
                 public enum Meta {
                     case red
-                case green
-                case blue
-                case gray
+                    case green
+                    case blue
+                    case gray
                     public init(_ __macro_local_6parentfMu_: Color) {
                         switch __macro_local_6parentfMu_ {
                             case .red:
@@ -276,11 +293,11 @@ final class MacroToolkitTests: XCTestCase {
 
                 var propertyWithSameName: Bool
 
-                func randomFunction() {
-                }
+                func randomFunction() {}
+
                 enum CodingKeys: String, CodingKey {
                     case propertyWithOtherName = "OtherName"
-                case propertyWithSameName
+                    case propertyWithSameName
                 }
             }
             """,


### PR DESCRIPTION
> __Since the swift-syntax dependency was updated and the PR fixes build errors, it would be nice to release 0.2.0 when it gets merged.__

- Updated and locked (_to avoid unexpected build errors_) swift-syntax version
- Fixed deprecation warnings
- Fixed compilation errors
- Fixed tests
- Couldn't fix AddAsync/AddCompletionHandler macros, they are called multiple times and produce diagnostic errors, but since it's a showcase I guess it shouldn't be a blocker for fixing compilation errors