### PR TITLE
Fix extra space in withAsyncModifier

### DIFF
--- a/Sources/MacroToolkit/SwiftSyntax+Extensions.swift
+++ b/Sources/MacroToolkit/SwiftSyntax+Extensions.swift
@@ -79,7 +79,7 @@ extension FunctionDeclSyntax {
                 .with(
                     \.effectSpecifiers,
                     effectSpecifiersOrDefault
-                        .with(\.asyncSpecifier, isPresent ? " async" : nil)
+                        .with(\.asyncSpecifier, isPresent ? "async" : nil)
                 )
         )
     }

--- a/Sources/MacroToolkit/Type.swift
+++ b/Sources/MacroToolkit/Type.swift
@@ -3,7 +3,7 @@ import SwiftSyntaxBuilder
 
 // TODO: Implement type normalisation and pretend sugar doesn't exist (e.g. Int? looks like Optional<Int> to devs)
 /// Wraps type syntax (e.g. `Result<Success, Failure>`).
-public enum Type: TypeProtocol, SyntaxExpressibleByStringInterpolation {
+public enum `Type`: TypeProtocol, SyntaxExpressibleByStringInterpolation {
     /// An array type (e.g. `[Int]`).
     case array(ArrayType)
     /// A `class` token in a conformance list. Equivalent to `AnyObject`.

--- a/Tests/MacroToolkitTests/MacroToolkitTests.swift
+++ b/Tests/MacroToolkitTests/MacroToolkitTests.swift
@@ -39,7 +39,7 @@ final class MacroToolkitTests: XCTestCase {
 
                 @Before
                 @After
-                func d(a: Int, for b: String, _ value: Double)  async -> Bool {
+                func d(a: Int, for b: String, _ value: Double) async -> Bool {
                     await withCheckedContinuation { continuation in
                         d(a: a, for: b, value) { returnValue in
                             continuation.resume(returning: returnValue)
@@ -576,7 +576,7 @@ final class MacroToolkitTests: XCTestCase {
             protocol API {
                 func request(completion: (Int) -> Void)
             
-                func request()  async -> Int
+                func request() async -> Int
             }
             """,
             macros: testMacros
@@ -598,9 +598,9 @@ final class MacroToolkitTests: XCTestCase {
                 func request1(completion: (Int) -> Void)
                 func request2(completion: (String) -> Void)
             
-                func request1()  async -> Int
+                func request1() async -> Int
 
-                func request2()  async -> String
+                func request2() async -> String
             }
             """,
             macros: testMacros
@@ -623,7 +623,7 @@ final class MacroToolkitTests: XCTestCase {
                     completion(0)
                 }
             
-                func request1()  async -> Int {
+                func request1() async -> Int {
                     await withCheckedContinuation { continuation in
                         request1() { returnValue in
                             continuation.resume(returning: returnValue)
@@ -658,7 +658,7 @@ final class MacroToolkitTests: XCTestCase {
                     completion("")
                 }
             
-                func request1()  async -> Int {
+                func request1() async -> Int {
                     await withCheckedContinuation { continuation in
                         request1() { returnValue in
                             continuation.resume(returning: returnValue)
@@ -666,7 +666,7 @@ final class MacroToolkitTests: XCTestCase {
                     }
                 }
 
-                func request2()  async -> String {
+                func request2() async -> String {
                     await withCheckedContinuation { continuation in
                         request2() { returnValue in
                             continuation.resume(returning: returnValue)


### PR DESCRIPTION
`withAsyncModifier` added an extra whitespace that resulted in a double whitespace in the output. I removed it and fixed the tests that expected two consecutive spaces in the generated code.

In addition, since `Type` is a Swift keyword, I added backticks around the declaration to make more clear the is a custom identifier and improve code highlighting.