### PR TITLE
Fixed float literal simple number case

### DIFF
--- a/Sources/MacroToolkit/FloatLiteral.swift
+++ b/Sources/MacroToolkit/FloatLiteral.swift
@@ -100,7 +100,7 @@ public struct FloatLiteral: LiteralProtocol {
 
             fractionalPartValue =
                 Double(fractionalPartDigitsValue)
-                / pow(Double(radix), Double(fractionalPart.count - 1))
+                / pow(Double(radix), Double(fractionalPartWithoutUnderscores.count))
         } else {
             fractionalPartValue = 0
         }

--- a/Tests/MacroToolkitTests/MacroToolkitTests.swift
+++ b/Tests/MacroToolkitTests/MacroToolkitTests.swift
@@ -360,6 +360,9 @@ final class MacroToolkitTests: XCTestCase {
         XCTAssertEqual(FloatLiteral(hexFloatLiteral)?.value, -0xFp-2_)
         XCTAssertEqual(
             FloatLiteral(hexFloatLiteralWithFractional)?.value, -0xF.0f_ep-2_, "Fair enough")
+        
+        XCTAssertEqual(FloatLiteral("1.1" as ExprSyntax)?.value, 1.1)
+        XCTAssertEqual(FloatLiteral("10.02" as ExprSyntax)?.value, 10.02)
     }
 
     func testStringLiteralParsing() {


### PR DESCRIPTION
Fixed that previously: `FloatLiteral("1.1" as ExprSyntax)?.value == 2.0` 